### PR TITLE
Add CLI separation and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Crossword Solver
+
+This repository provides a small crossword solver written in plain JavaScript. The core logic lives in `solver.js` and can be used as a library or via the simple command line interface in `cli.js`.
+
+## Usage
+
+### As a Module
+
+```javascript
+const { crosswordSolver } = require('./solver');
+const result = crosswordSolver('1..\n...', ['HI']);
+console.log(result); // prints either the filled grid or 'Error'
+```
+
+### CLI
+
+```
+node cli.js "<puzzle string>" "[\"WORD1\",\"WORD2\"]"
+```
+
+The puzzle string is a grid where digits mark word starting points and `.` marks blocked cells. Words are provided as a JSON array.
+
+## Tests
+
+A very small test script resides in `test/test.js` and can be run with Node:
+
+```
+node test/test.js
+```
+
+## Architecture Notes
+
+- `solver.js` exports the `crosswordSolver` function and contains no CLI logic.
+- `cli.js` handles command line parsing and prints the solver result.
+- The solver expects a unique solution; otherwise it returns `'Error'`.
+
+

--- a/cli.js
+++ b/cli.js
@@ -1,0 +1,17 @@
+#!/usr/bin/env node
+const { crosswordSolver } = require('./solver');
+
+const [,, puzzleArg, wordsArg] = process.argv;
+
+try {
+  if (!puzzleArg || !wordsArg) {
+    console.error('Usage: node cli.js "<puzzle>" "[\"WORD1\",\"WORD2\"]"');
+    process.exit(1);
+  }
+  const puzzle = puzzleArg;
+  const words = JSON.parse(wordsArg);
+  const result = crosswordSolver(puzzle, words);
+  console.log(result);
+} catch (err) {
+  console.error('Error');
+}

--- a/solver.js
+++ b/solver.js
@@ -1,18 +1,14 @@
 /**
- * crosswordSolver.js
+ * solver.js
  *
- * A production-ready, framework-free JavaScript module that solves an empty crossword puzzle.
- * It reads a string representation of the puzzle, fills in words from a provided list,
- * ensures a unique solution, and prints the filled puzzle or 'Error' otherwise.
+ * Provides crosswordSolver, a framework-free function that fills an empty crossword puzzle from a list of words.
  *
  * Usage:
- *   node crosswordSolver.js
- *   // The module exports crosswordSolver for integration or testing.
+ *   const { crosswordSolver } = require("./solver");
  *
  * @module crosswordSolver
  */
 'use strict';
-
 /**
  * Solve an empty crossword puzzle given a grid and a word list.
  * The grid is described as a string, where:
@@ -25,7 +21,7 @@
  * The solver must find a unique way to place every word exactly once.
  *
  * If the inputs don't guarantee a unique solution, or violate constraints,
- * it prints 'Error'. On success, it prints the filled puzzle string.
+ * it returns 'Error'. On success, it returns the filled puzzle string.
  *
  * @param {string} puzzleStr - The empty puzzle layout.
  * @param {string[]} words - List of words to fit (no duplicates).
@@ -34,12 +30,12 @@ function crosswordSolver(puzzleStr, words) {
   // Parse input
   const rows = puzzleStr.split('\n').map(line => line.split(''));
   const height = rows.length;
-  if (height === 0) return console.log('Error');
+  if (height === 0) return 'Error';
   const width = rows[0].length;
 
   // Validate grid consistency
   for (const row of rows) {
-    if (row.length !== width) return console.log('Error');
+    if (row.length !== width) return 'Error';
   }
 
   // Utility to clone a 2D array
@@ -87,7 +83,7 @@ function crosswordSolver(puzzleStr, words) {
   }
 
   // Quick validation: word counts must match slot counts
-  if (words.length !== slots.length) return console.log('Error');
+  if (words.length !== slots.length) return 'Error';
 
   // Prepare state
   const assignments = Array(slots.length).fill(null);
@@ -146,26 +142,11 @@ function crosswordSolver(puzzleStr, words) {
   const workingGrid = rows.map(row => row.map(ch => (ch === '.' ? '.' : ch)));
   backtrack(0, workingGrid);
 
-  // Output result
   if (solutionCount === 1 && finalGrid) {
-    // Convert to string, replace digits with letters as filled
     const result = finalGrid.map(r => r.join('')).join('\n');
-    console.log(result);
-  } else {
-    console.log('Error');
+    return result;
   }
-}
-
-// If run as CLI, read from process args or stdin
-if (require.main === module) {
-  const [,, puzzleArg, wordsArg] = process.argv;
-  try {
-    const puzzle = puzzleArg;
-    const words = JSON.parse(wordsArg);
-    crosswordSolver(puzzle, words);
-  } catch (err) {
-    console.error('Error');
-  }
+  return 'Error';
 }
 
 module.exports = { crosswordSolver };

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const { crosswordSolver } = require('../solver');
+
+// Basic invalid puzzle should return 'Error'
+const result = crosswordSolver('1..\n...', ['hi']);
+assert.strictEqual(result, 'Error');
+
+console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- rename `crosswordSolver.js` to `solver.js`
- return puzzle string instead of printing inside solver
- add standalone `cli.js` for command line use
- document usage and architecture in README
- provide minimal test example

## Testing
- `node test/test.js`

------
https://chatgpt.com/codex/tasks/task_e_6870c4daba60832496219e2d31fb4cf2