### PR TITLE
Add Latin character validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ node cli.js "<puzzle string>" "[\"WORD1\",\"WORD2\"]"
 ```
 
 The puzzle string is a grid where digits mark word starting points and `.` marks blocked cells. Words are provided as a JSON array.
+Words must contain only Latin letters (A-Z or a-z). The puzzle string may only include digits, periods, and newlines.
 
 ## Tests
 

--- a/solver.js
+++ b/solver.js
@@ -34,6 +34,9 @@ function crosswordSolver(puzzleStr, words) {
   if (puzzleStr.trim() === '') return 'Error: empty puzzle';
   if (words.some(w => typeof w !== 'string')) return 'Error: invalid words list';
   if (new Set(words).size !== words.length) return 'Error: duplicate words';
+  if (/[^0-9.\n]/.test(puzzleStr)) return 'Error: invalid puzzle characters';
+  const latinRegex = /^[A-Za-z]+$/;
+  if (words.some(w => !latinRegex.test(w))) return 'Error: invalid word characters';
 
   const rows = puzzleStr.split('\n').map(line => line.split(''));
   const height = rows.length;

--- a/test/test.js
+++ b/test/test.js
@@ -47,5 +47,9 @@ assert.strictEqual(crosswordSolver(puzzle3, words3), expect3);
 // Invalid puzzle
 assert.ok(crosswordSolver('', ['a']).startsWith('Error'));
 assert.ok(crosswordSolver('0001\n0..0\n3000\n0..0', ['a']).startsWith('Error'));
+// Invalid characters
+assert.ok(crosswordSolver("😀", ["hi"]).startsWith("Error"));
+assert.ok(crosswordSolver("1000", ["hí"]).startsWith("Error"));
+
 
 console.log('All tests passed.');


### PR DESCRIPTION
## Summary
- disallow non-Latin characters in input words and invalid symbols in the puzzle
- document character restrictions in README
- test invalid character cases

## Testing
- `node test/test.js`

------
https://chatgpt.com/codex/tasks/task_e_6870d2cdf3088324af81b0bb2d28ecbc